### PR TITLE
used puppet-lint to remove trailing whitespace

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,19 +12,19 @@
 #
 # Usage:
 #
-#   dotnet { 'dotnet45': 
+#   dotnet { 'dotnet45':
 #     version => '4.5',
 #   }
 define dotnet(
   $ensure  = 'present',
   $version = '',
 ) {
-    
+
   validate_re($ensure,['^(present|absent)$'])
   validate_re($version,['^(3.5|4|4.5)$'])
 
   include dotnet::params
-  
+
   if $ensure == 'present' {
     case $version {
       '3.5': {
@@ -103,12 +103,12 @@ define dotnet(
               provider  => powershell,
               logoutput => true,
               unless    => "if ((Get-Item -LiteralPath \'${dotnet::params::t_reg_key}\' -ErrorAction SilentlyContinue).GetValue(\'DisplayVersion\')) { exit 1 }"
-            }                 
+            }
           }
           default: {
             err('dotnet 3.5 is not supported on this version of windows')
           }
-        }  
+        }
       }
       '4': {
         case $::operatingsystemversion {
@@ -142,4 +142,4 @@ define dotnet(
       }
     }
   }
-}   
+}


### PR DESCRIPTION
Before:

$ puppet-lint --no-80chars-check init.pp

ERROR: trailing whitespace found on line 15
ERROR: trailing whitespace found on line 22
ERROR: trailing whitespace found on line 27
ERROR: trailing whitespace found on line 106
ERROR: trailing whitespace found on line 111
ERROR: trailing whitespace found on line 145

After:

$ puppet-lint --no-80chars-check init.pp
$
