### PR TITLE
Fix warning on puppet 3.x because of unescaped \

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,7 +34,7 @@ define dotnet(
               command   => "${dotnet::params::ps_command} Import-Module ServerManager; Add-WindowsFeature as-net-framework",
               provider  => windows,
               logoutput => true,
-              unless    => "${dotnet::params::ps_command} Test-Path C:\Windows\Microsoft.NET\Framework\v3.5",
+              unless    => "${dotnet::params::ps_command} Test-Path C:\\Windows\\Microsoft.NET\\Framework\\v3.5",
             }
           }
           'Windows XP','Windows Vista','Windows 7','Windows 8': {
@@ -94,7 +94,7 @@ define dotnet(
               command   => "${dotnet::params::ps_command} Import-Module ServerManager; Remove-WindowsFeature as-net-framework",
               provider  => windows,
               logoutput => true,
-              onlyif    => "${dotnet::params::ps_command} Test-Path C:\Windows\Microsoft.NET\Framework\v3.5",
+              onlyif    => "${dotnet::params::ps_command} Test-Path C:\\Windows\\Microsoft.NET\\Framework\\v3.5",
             }
           }
           'Windows XP','Windows Vista','Windows 7','Windows 8': {


### PR DESCRIPTION
Replace `\` with `\\` to avoid those warnings:

  Warning: Unrecognised escape sequence '\M' in file C:/tmp/vagrant-puppet/modules-0/dotnet/manifests/init.pp at line 97
