### PR TITLE
Inside params.pp the exe param is incorrect for 4.5.2 version

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,7 +32,7 @@ class dotnet::params {
     },
     '4.5.2' => {
       'url' => 'http://download.microsoft.com/download/E/2/1/E21644B5-2DF2-47C2-91BD-63C560427900/NDP452-KB2901907-x86-x64-AllOS-ENU.exe',
-      'exe' => 'NDP451-KB2858728-x86-x64-AllOS-ENU.exe',
+      'exe' => 'NDP452-KB2901907-x86-x64-AllOS-ENU.exe',
       'key' => 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{26784146-6E05-3FF9-9335-786C7C0FB5BE}'
     }
   }


### PR DESCRIPTION
This is a quick change that addresses the line 'exe' => 'NDP451-KB2858728-x86-x64-AllOS-ENU.exe' inside params.pp under the 4.5.2 dot net version. The exe name is wrong and so when trying to install dot net 4.5.2 the module will fail. The change replaces the exe name with the correct name.